### PR TITLE
Unbreak build of sample conversion utility.

### DIFF
--- a/convert-utility/Makefile.am
+++ b/convert-utility/Makefile.am
@@ -14,7 +14,7 @@
 
 bin_PROGRAMS = alacconvert$(EXEEXT)
 
-alacconvert_CPPFLAGS = -Wno-multichar
+alacconvert_CPPFLAGS = -Wno-multichar -I../codec
 alacconvert_LDADD = ../codec/libalac.la
 alacconvert_SOURCES = \
     main.cpp \


### PR DESCRIPTION
Just a tiny path fix to actually find ALACEncoder.h.