### PR TITLE
Add ability to build alac from external output folder

### DIFF
--- a/codec/Makefile.am
+++ b/codec/Makefile.am
@@ -35,5 +35,12 @@ pkgconfig_DATA = alac.pc
 # Install to include/alac
 alacincludedir = $(includedir)/alac
 
-# Install everything
-alacinclude_HEADERS = *.h
+alacinclude_HEADERS = \
+    ALACAudioTypes.h \
+    ALACBitUtilities.h \
+    ALACDecoder.h \
+    ALACEncoder.h \
+    EndianPortable.h \
+    aglib.h \
+    dplib.h \
+    matrixlib.h


### PR DESCRIPTION
The `alac` library can't be built from an external output folder.

```
$ autoreconf -fi 
$ mkdir build
$ cd build/
$ ../configure
$ make -j1

make[2]: *** No rule to make target '*.h', needed by 'all-am'.  Stop.
make[1]: *** [Makefile:404: all-recursive] Error 1
make: *** [Makefile:336: all] Error 2
```

The solution is to specify headers required for building codec explicitly.